### PR TITLE
Run init_mongo.js every time the docker is started

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ MAINTAINER Jim White <james_white2@dell.com>
 
 #copy initialization script for later initialization
 COPY *.js /edgex/mongo/config/
+COPY launch-edgex-mongo.sh /edgex/mongo/config/
 
 #expose Mongodb's port
 EXPOSE 27017
+
+CMD /edgex/mongo/config/launch-edgex-mongo.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@
 FROM mongo:latest
 MAINTAINER Jim White <james_white2@dell.com>
 
+ENV SLEEP_TIME_BEFORE_CONFIG=10
+
 #copy initialization script for later initialization
 COPY *.js /edgex/mongo/config/
 COPY launch-edgex-mongo.sh /edgex/mongo/config/

--- a/launch-edgex-mongo.sh
+++ b/launch-edgex-mongo.sh
@@ -19,7 +19,8 @@ set -e
 
 mongod --smallfiles &
 
-sleep 10
+echo "Waiting for $SLEEP_TIME_BEFORE_CONFIG seconds before configuring mongo"
+sleep $SLEEP_TIME_BEFORE_CONFIG
 
 mongo /edgex/mongo/config/init_mongo.js
 

--- a/launch-edgex-mongo.sh
+++ b/launch-edgex-mongo.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+mongod --smallfiles &
+
+sleep 10
+
+mongo /edgex/mongo/config/init_mongo.js
+
+wait
+

--- a/launch-edgex-mongo.sh
+++ b/launch-edgex-mongo.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
 
+# Copyright 2017 Cavium Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 set -e
 
 mongod --smallfiles &


### PR DESCRIPTION
With this change docker-edgex-mongo-seed is no longer needed as the init_mongo.js is executed some seconds after the docker is started.

This change needs a change to docker-compose.yml that is in a different pull request in developer-scripts.