### PR TITLE
updating init_mongo.js support-scheduler index on name not slug

### DIFF
--- a/init_mongo.js
+++ b/init_mongo.js
@@ -114,8 +114,8 @@ db.createUser({ user: "scheduler",
 });
 db.createCollection("interval");
 db.createCollection("intervalAction");
-db.interval.createIndex({slug: 1}, {unique: true});
-db.intervalAction.createIndex({slug: 1}, {unique: true});
+db.interval.createIndex({name: 1}, {unique: true});
+db.intervalAction.createIndex({name: 1}, {unique: true});
 
 db=db.getSiblingDB('logging')
 db.createUser({ user: "logging",


### PR DESCRIPTION
Change #16 
This places the index in the mongo support-scheduler DB on "name" and not "slug"

Signed-off-by: xmlviking <ecotter@gmail.com>