### PR TITLE
Add index to Mongo for Reading's device field

### DIFF
--- a/init_mongo.js
+++ b/init_mongo.js
@@ -80,8 +80,10 @@ db.createUser({ user: "core",
   ]
 });
 db.createCollection("event");
+db.event.createIndex({"device": 1}, {unique: false});
 db.createCollection("reading");
 db.createCollection("valueDescriptor");
+db.reading.createIndex({"device": 1}, {unique: false});
 db.valueDescriptor.createIndex({name: 1}, {unique: true});
 
 db=db.getSiblingDB('rules_engine_db')


### PR DESCRIPTION
Fix #19
Related to: EdgeX-GO #1286

Add an index to the reading collection for the device field which will
allow for more effective deletions when deleting all readings associated
with a specific device. This will prevent the database manager from
performing a full scan.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>