### PR TITLE
Remove the re-try loop from the bash file

### DIFF
--- a/bin/edgex-mongo-launch.sh
+++ b/bin/edgex-mongo-launch.sh
@@ -17,9 +17,6 @@ mongod --smallfiles --bind_ip_all &
 # Run Edgex-Mongo Go Application and keep the process/container alive
 ###
 cd cmd/
-while true; do
-  ./edgex-mongo && break
-  sleep 10
-done
+./edgex-mongo
 wait
 


### PR DESCRIPTION
Remove the re-try loop from the bash file

and stay with the already existing retry mechanism for getting database session. 
The BootTimeout is configurable. The default value is up to 30 seconds.
Fix: https://github.com/edgexfoundry/docker-edgex-mongo/issues/36

Signed-off-by: difince <dianaa@vmware.com>