### PR TITLE
Prevent snap builds of failing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,8 +36,8 @@ func main() {
 
 	//TODO When Vault Integration is added the check: if env == "" should be removed! It is temporary added for sake of Snap builds.
 	//The default behaviour in case secretStore is not present is to read the credentials from Vault
-	switch env := os.Getenv(pkg.SecretStore); {
-	case env == "false" || env == "":
+	switch env, ok := os.LookupEnv(pkg.SecretStore); {
+	case !ok || env == "false":
 		config, err = unsecure.LoadConfig()
 	default:
 		config, err = secure.LoadConfig()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,8 +34,10 @@ func main() {
 	var err error
 	var config *pkg.Configuration
 
+	//TODO When Vault Integration is added the check: if env == "" should be removed! It is temporary added for sake of Snap builds.
+	//The default behaviour in case secretStore is not present is to read the credentials from Vault
 	switch env := os.Getenv(pkg.SecretStore); {
-	case env == "false":
+	case env == "false" || env == "":
 		config, err = unsecure.LoadConfig()
 	default:
 		config, err = secure.LoadConfig()


### PR DESCRIPTION
If env var EDGEX_SECURITY_SECRET_STORE is not present -> temporary work in unsecured mode
Once vault integration is done, this should be reverted.

Signed-off-by: difince <dianaa@vmware.com>