### PR TITLE
Upgrade Mongo image to mongo:4.2.0-bionic

### DIFF
--- a/bin/edgex-mongo-launch.sh
+++ b/bin/edgex-mongo-launch.sh
@@ -11,7 +11,7 @@ set -e
 ###
 # Run MongoDB
 ###
-mongod --smallfiles --bind_ip_all &
+mongod --bind_ip_all &
 
 ###
 # Run Edgex-Mongo Go Application and keep the process/container alive

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -32,7 +32,7 @@ COPY . .
 
 RUN make cmd/edgex-mongo
 
-FROM mongo:4.0-xenial
+FROM mongo:4.2.0-bionic
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: VMWare'


### PR DESCRIPTION
Because of Snyk reports lots of Common vulnerabilities and exposures
the docker-edgex-mongo start using instead of mongo:4.0-xenial, but mongo:4.2.0-bionic.
Flag '--smallfiles' not available anymore.

Fix: https://github.com/edgexfoundry/docker-edgex-mongo/issues/43

Signed-off-by: difince <dianaa@vmware.com>