### PR TITLE
Use dumb-init and keep image size small 

### DIFF
--- a/bin/edgex-mongo-launch.sh
+++ b/bin/edgex-mongo-launch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/dumb-init /bin/bash
 #
 # Copyright (c) 2019 VMWare
 #

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -37,7 +37,8 @@ FROM mongo:4.2.0-bionic
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: VMWare'
 
-RUN apt update && apt install curl
+RUN apt update && apt install curl dumb-init \
+ && rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 27017
 WORKDIR /edgex-mongo


### PR DESCRIPTION
Use dumb-init and keep image size small

Fix: https://github.com/edgexfoundry/docker-edgex-mongo/issues/37
Signed-off-by: difince <dianaa@vmware.com>