### PR TITLE
Reflect changes done in SecretClient interface

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -26,7 +26,7 @@
 [SecretStore]
   Server = "localhost"
   Port = 8200
-  DBStem = "/v1/secret/edgex/dbcredentials"
+  Path = "/v1/secret/edgex/mongodb"
   CACertPath = "/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
   TokenPath = "/vault/config/assets/resp-init.json"
   SNI = "localhost"

--- a/cmd/res/docker/configuration.toml
+++ b/cmd/res/docker/configuration.toml
@@ -26,7 +26,7 @@
 [SecretStore]
   Server = "edgex-vault"
   Port = 8200
-  DBStem = "/v1/secret/edgex/dbcredentials"
+  Path = "/v1/secret/edgex/mongodb"
   CACertPath = "/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
   TokenPath = "/vault/config/assets/resp-init.json"
   SNI = "edgex-vault"

--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -57,7 +57,7 @@ type SecretStoreInfo struct {
 	Port       int
 	TokenPath  string
 	CACertPath string
-	DBStem     string
+	Path       string
 	// SNI - Server Name Identifier
 	SNI string
 }


### PR DESCRIPTION
getSecrets method now accepts as first argument "path" variable
Because of this change, only one instance of secretClient is created.
rename RootCaCert - to RootCaCertPath
rename SecretStore.DBStem to Path
Fix: #49 
Signed-off-by: difince <dianaa@vmware.com>