### PR TITLE
Reflect changes done in SecretClient interface

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -26,7 +26,7 @@
 [SecretStore]
   Server = "localhost"
   Port = 8200
-  DBStem = "/v1/secret/edgex/dbcredentials"
+  Path = "/v1/secret/edgex/mongo"
   CACertPath = "/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
   TokenPath = "/vault/config/assets/resp-init.json"
   SNI = "localhost"

--- a/cmd/res/docker/configuration.toml
+++ b/cmd/res/docker/configuration.toml
@@ -26,7 +26,7 @@
 [SecretStore]
   Server = "edgex-vault"
   Port = 8200
-  DBStem = "/v1/secret/edgex/dbcredentials"
+  Path = "/v1/secret/edgex/mongo"
   CACertPath = "/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
   TokenPath = "/vault/config/assets/resp-init.json"
   SNI = "edgex-vault"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/docker-edgex-mongo
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.17
-	github.com/edgexfoundry/go-mod-secrets v0.0.4
+	github.com/edgexfoundry/go-mod-secrets v0.0.7
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -57,7 +57,7 @@ type SecretStoreInfo struct {
 	Port       int
 	TokenPath  string
 	CACertPath string
-	DBStem     string
+	Path       string
 	// SNI - Server Name Identifier
 	SNI string
 }


### PR DESCRIPTION
Update docker-edgex-mongo to reflect the changes done by PR edgexfoundry/go-mod-secrets#31 , issue edgexfoundry/go-mod-secrets#26

The SecretConfig struct retains its Path variable, that provides the base searching path for vault, meanwhile the SecretClient interface changed its signature to
GetSecrets(path string, keys ...string) (map[string]string, error)
This path, if provided, will be attached to the base searching path - thus each microservice will be able to read secrets from different paths (under their base search path)
renamed: RootCaCert - to RootCaCertPath
path updated to /v1/secret/edgex/mongo
update go.mod file

Fix: https://github.com/edgexfoundry/docker-edgex-mongo/pull/51
Signed-off-by: difince <dianaa@vmware.com>