### PR TITLE
Keep database names consistent

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -36,34 +36,34 @@
   Port = 27017
   Timeout = 5000
 
-[Credentials]
-    [Credentials.authorization]
+[Databases]
+    [Databases.authorization]
        Username = "admin"
        Password = "password"
-    [Credentials.admin]
+    [Databases.admin]
        Username = "admin"
        Password = "password"
-    [Credentials.metadata]
+    [Databases.metadata]
        Username = "meta"
        Password = "password"
-    [Credentials.coredata]
+    [Databases.coredata]
        Username = "core"
        Password = "password"
-    [Credentials.rules_engine_db]
-       Username = "rules_engine_user"
+    [Databases.rulesengine]
+       Username = "rulesengine"
        Password = "password"
-    [Credentials.notifications]
+    [Databases.notifications]
        Username = "notifications"
        Password = "password"
-    [Credentials.scheduler]
+    [Databases.scheduler]
        Username = "scheduler"
        Password = "password"
-    [Credentials.logging]
+    [Databases.logging]
        Username = "logging"
        Password = "password"
-    [Credentials.exportclient]
+    [Databases.exportclient]
        Username = "exportclient"
        Password = "password"
-    [Credentials.application-service]
-       Username = "application-service"
+    [Databases.application-service]
+       Username = "appservice"
        Password = "password"

--- a/cmd/res/docker/configuration.toml
+++ b/cmd/res/docker/configuration.toml
@@ -36,34 +36,34 @@
   Port = 27017
   Timeout = 5000
 
-[Credentials]
-    [Credentials.authorization]
+[Databases]
+    [Databases.authorization]
        Username = "admin"
        Password = "password"
-    [Credentials.admin]
+    [Databases.admin]
        Username = "admin"
        Password = "password"
-    [Credentials.metadata]
+    [Databases.metadata]
        Username = "meta"
        Password = "password"
-    [Credentials.coredata]
+    [Databases.coredata]
        Username = "core"
        Password = "password"
-    [Credentials.rules_engine_db]
-       Username = "rules_engine_user"
+    [Databases.rulesengine]
+       Username = "rulesengine"
        Password = "password"
-    [Credentials.notifications]
+    [Databases.notifications]
        Username = "notifications"
        Password = "password"
-    [Credentials.scheduler]
+    [Databases.scheduler]
        Username = "scheduler"
        Password = "password"
-    [Credentials.logging]
+    [Databases.logging]
        Username = "logging"
        Password = "password"
-    [Credentials.exportclient]
+    [Databases.exportclient]
        Username = "exportclient"
        Password = "password"
-    [Credentials.application-service]
-       Username = "application-service"
+    [Databases.application-service]
+       Username = "appservice"
        Password = "password"

--- a/internal/client.go
+++ b/internal/client.go
@@ -12,7 +12,7 @@ var DatabaseCollectionsMap = map[string]func(db *mgo.Database){
 	"authorization":       nil,
 	"metadata":            createMetadataCollections,
 	"coredata":            createCoredataCollections,
-	"rules_engine_db":     nil,
+	"rulesengine":     nil,
 	"notifications":       createNotificationCollections,
 	"scheduler":           createSchedulerCollections,
 	"logging":             createLoggingCollections,
@@ -50,8 +50,8 @@ func (client *DBInitClient) createDatabase(session *mgo.Session, dbName string, 
 	}
 
 	err := db.UpsertUser(&mgo.User{
-		Username: client.Configuration.Credentials[dbName].Username,
-		Password: client.Configuration.Credentials[dbName].Password,
+		Username: client.Configuration.Databases[dbName].Username,
+		Password: client.Configuration.Databases[dbName].Password,
 		Roles: []mgo.Role{
 			mgo.RoleReadWrite,
 		},

--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -20,14 +20,14 @@ import (
 )
 
 type Configuration struct {
-	Service     ServiceInfo
-	Writable    WritableInfo
-	Mongo       MongoInfo
-	Credentials map[string]CredentialsInfo
+	Service   ServiceInfo
+	Writable  WritableInfo
+	Mongo     MongoInfo
+	Databases map[string]DatabaseInfo
 }
 
-func (c *Configuration) UpdateCredentials(credentials map[string]CredentialsInfo) {
-	c.Credentials = credentials
+func (c *Configuration) UpdateCredentials(databases map[string]DatabaseInfo) {
+	c.Databases = databases
 }
 
 type ServiceInfo struct {
@@ -42,7 +42,7 @@ type MongoInfo struct {
 	Timeout int
 }
 
-type CredentialsInfo struct {
+type DatabaseInfo struct {
 	Username string
 	Password string
 }


### PR DESCRIPTION
- "Rule_engine_db" databases come "ruleengine"
- application-service database Username become "appservice"
- get databases names from the config file
- renaming in toml file: "Credentials" replaced with "Databases"

https://github.com/edgexfoundry/edgex-go/issues/1891
Signed-off-by: difince <dianaa@vmware.com>