### PR TITLE
Dockerfile: add curl to the base image

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -37,6 +37,8 @@ FROM mongo:4.2.0-bionic
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: VMWare'
 
+RUN apt update && apt install curl
+
 EXPOSE 27017
 WORKDIR /edgex-mongo
 COPY --from=builder /edgex-mongo/cmd/edgex-mongo /edgex-mongo/cmd/


### PR DESCRIPTION
We need this to do dependency checking to ensure that docker-edgex-mongo isn't started until after security-secretstore-setup finishes running. 

the associated change in docker-compose is in my developer-scripts PR here: https://github.com/edgexfoundry/developer-scripts/pull/172

Partially resolves https://github.com/edgexfoundry/developer-scripts/issues/167