### PR TITLE
internal/secure/config.go: specify 10 retry attempts @ 1 Hz

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -30,6 +30,8 @@
   CACertPath = "/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
   TokenPath = "/vault/config/assets/resp-init.json"
   SNI = "localhost"
+  AdditionalRetryAttempts = 10
+  RetryWaitPeriod = "1s"
 
 [Mongo]
   Host = 'localhost'

--- a/cmd/res/docker/configuration.toml
+++ b/cmd/res/docker/configuration.toml
@@ -30,6 +30,8 @@
   CACertPath = "/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
   TokenPath = "/vault/config/assets/resp-init.json"
   SNI = "edgex-vault"
+  AdditionalRetryAttempts = 10
+  RetryWaitPeriod = "1s"
 
 [Mongo]
   Host = 'localhost'

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/docker-edgex-mongo
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.17
-	github.com/edgexfoundry/go-mod-secrets v0.0.7
+	github.com/edgexfoundry/go-mod-secrets v0.0.9
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -59,7 +59,9 @@ type SecretStoreInfo struct {
 	CACertPath string
 	Path       string
 	// SNI - Server Name Identifier
-	SNI string
+	SNI                     string
+	AdditionalRetryAttempts int
+	RetryWaitPeriod         string
 }
 
 func (s SecretStoreInfo) GetSecretStoreBaseURL() string {

--- a/internal/secure/config.go
+++ b/internal/secure/config.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	"github.com/BurntSushi/toml"
 
@@ -49,13 +50,15 @@ func LoadConfig() (*pkg.Configuration, error) {
 	}
 
 	secretClient, err := secrets.NewSecretClient(secrets.SecretConfig{
-		Port:           secureConfig.SecretStore.Port,
-		Host:           secureConfig.SecretStore.Server,
-		Path:           secureConfig.SecretStore.Path,
-		Protocol:       "https",
-		RootCaCertPath: secureConfig.SecretStore.CACertPath,
-		ServerName:     secureConfig.SecretStore.SNI,
-		Authentication: secrets.AuthenticationInfo{AuthType: pkg.VaultToken, AuthToken: token},
+		Port:                    secureConfig.SecretStore.Port,
+		Host:                    secureConfig.SecretStore.Server,
+		Path:                    secureConfig.SecretStore.Path,
+		Protocol:                "https",
+		RootCaCertPath:          secureConfig.SecretStore.CACertPath,
+		ServerName:              secureConfig.SecretStore.SNI,
+		Authentication:          secrets.AuthenticationInfo{AuthType: pkg.VaultToken, AuthToken: token},
+		AdditionalRetryAttempts: 10,
+		RetryWaitPeriod:         time.Second,
 	})
 
 	if err != nil {
@@ -66,7 +69,7 @@ func LoadConfig() (*pkg.Configuration, error) {
 	var credentials = make(map[string]pkg.DatabaseInfo)
 	for _, dbName := range getDatabaseNames(secureConfig) {
 		pkg.LoggingClient.Debug(fmt.Sprintf("reading secrets from '%s/%s' path", secureConfig.SecretStore.Path, dbName))
-		secrets, err := secretClient.GetSecrets("/"+dbName,"username", "password")
+		secrets, err := secretClient.GetSecrets("/"+dbName, "username", "password")
 		if err != nil {
 			pkg.LoggingClient.Error(fmt.Sprintf("failed to read secret stores data for '%s/%s' path: %s", secureConfig.SecretStore.Path, dbName, err.Error()))
 			return nil, err

--- a/internal/secure/config.go
+++ b/internal/secure/config.go
@@ -44,6 +44,11 @@ func LoadConfig() (*pkg.Configuration, error) {
 		return nil, err
 	}
 
+	retryWaitPeriodTime, err := time.ParseDuration(secureConfig.SecretStore.RetryWaitPeriod)
+	if err != nil {
+		return nil, err
+	}
+
 	token, err := getAccessToken(secureConfig.SecretStore.TokenPath)
 	if err != nil {
 		return nil, err
@@ -57,8 +62,8 @@ func LoadConfig() (*pkg.Configuration, error) {
 		RootCaCertPath:          secureConfig.SecretStore.CACertPath,
 		ServerName:              secureConfig.SecretStore.SNI,
 		Authentication:          secrets.AuthenticationInfo{AuthType: pkg.VaultToken, AuthToken: token},
-		AdditionalRetryAttempts: 10,
-		RetryWaitPeriod:         time.Second,
+		AdditionalRetryAttempts: secureConfig.SecretStore.AdditionalRetryAttempts,
+		RetryWaitPeriod:         retryWaitPeriodTime,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This will fix the race condition we currently have when security-secretstore-setup is run at the same time as docker-edgex-mongo and the secrets haven't been put into vault yet and currently docker-edgex-mongo immediately fails when vault returns a 404 for the secret.

This depends on https://github.com/edgexfoundry/go-mod-secrets/pull/36.

To test this, I pushed the above go-mod-secrets change to master at my fork, so if you add the following to your go.mod:

```
replace github.com/edgexfoundry/go-mod-secrets => github.com/anonymouse64/go-mod-secrets v0.0.8-0.20191105235208-65a79df9754e
```

then you should be able to build this. To test it, build the docker container here with:
```
$ make docker
```

and checkout master branch of developer-scripts and follow all the testing instructions for this at https://github.com/edgexfoundry/developer-scripts/pull/172, but also replacing the image to use for mongo with your local copy you just built, i.e. also apply this patch to the developer-scripts repo;

```patch
index d071618..0dbfe3f 100644
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -228,7 +228,7 @@ services:
 # end of containers for reverse proxy
 
   mongo:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-mongo:1.1.0
+    image: edgexfoundry/docker-edgex-mongo:1.1.0
     ports:
       - "27017:27017"
     container_name: edgex-mongo
```

Then finally, run docker-compose up on the nightly-build docker-compose file like so:

```
$ docker volume prune -f
$ docker-compose -f ./releases/nightly-build/compose-files/docker-compose-nexus.yml up -d
```

and check that edgex-mongo container started successfully. I checked this 5 times and it worked every time. You should see output like this:

```
$ docker logs edgex-mongo+ cd /consul/scripts
+ command -v jq
/usr/bin/jq
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ jq -r .[] | select(.ServiceName == "security-secretstore-setup") | .Status == "passing"
+ [ true = false ]
+ exit 2
+ cd /consul/scripts
+ command -v jq
/usr/bin/jq
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ jq -r .[] | select(.ServiceName == "security-secretstore-setup") | .Status == "passing"
+ [ true = true ]
+ cd /consul/scripts
+ command -v jq
/usr/bin/jq
+ curl -s -G edgex-core-consul:8500/v1/agent/checks
+ jq -r .[] | select(.ServiceName == "vault") | .Status == "passing"
+ [ true = true ]
level=ERROR ts=2019-11-06T00:20:05.650653894Z app=edgex-mongo source=logger.go:105 msg="logTarget cannot be blank, using stdout only"
level=INFO ts=2019-11-06T00:20:05.650707477Z app=edgex-mongo source=main.go:32 msg="starting edgex-mongo process ..."
level=INFO ts=2019-11-06T00:20:05.650723732Z app=edgex-mongo source=config.go:39 msg="loading configuration considering the secret store"
level=INFO ts=2019-11-06T00:20:05.65073991Z app=edgex-mongo source=init.go:47 msg="config file location: res/docker/configuration.toml"
2019-11-06T00:20:05.666+0000 I  CONTROL  [main] Automatically disabling TLS 1.0, to force-enable TLS 1.0 specify --sslDisabledProtocols 'none'
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten] MongoDB starting : pid=25 port=27017 dbpath=/data/db 64-bit host=edgex-mongo
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten] db version v4.2.0
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten] git version: a4b751dcf51dd249c5865812b390cfd1c0129c30
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.1.1  11 Sep 2018
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten] allocator: tcmalloc
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten] modules: none
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten] build environment:
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten]     distmod: ubuntu1804
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten]     distarch: x86_64
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten]     target_arch: x86_64
2019-11-06T00:20:05.672+0000 I  CONTROL  [initandlisten] options: { net: { bindIp: "*" } }
2019-11-06T00:20:05.672+0000 I  STORAGE  [initandlisten] 
2019-11-06T00:20:05.672+0000 I  STORAGE  [initandlisten] ** WARNING: Using the XFS filesystem is strongly recommended with the WiredTiger storage engine
2019-11-06T00:20:05.672+0000 I  STORAGE  [initandlisten] **          See http://dochub.mongodb.org/core/prodnotes-filesystem
2019-11-06T00:20:05.672+0000 I  STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=7433M,cache_overflow=(file_max=0M),session_max=33000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),statistics_log=(wait=0),verbose=[recovery_progress,checkpoint_progress],
2019-11-06T00:20:06.220+0000 I  STORAGE  [initandlisten] WiredTiger message [1572999606:220203][25:0x7f8da7841b00], txn-recover: Set global recovery timestamp: (0,0)
2019-11-06T00:20:06.253+0000 I  RECOVERY [initandlisten] WiredTiger recoveryTimestamp. Ts: Timestamp(0, 0)
2019-11-06T00:20:06.292+0000 I  STORAGE  [initandlisten] Timestamp monitor starting
2019-11-06T00:20:06.313+0000 I  CONTROL  [initandlisten] 
2019-11-06T00:20:06.313+0000 I  CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
2019-11-06T00:20:06.313+0000 I  CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
2019-11-06T00:20:06.313+0000 I  CONTROL  [initandlisten] ** WARNING: You are running this process as the root user, which is not recommended.
2019-11-06T00:20:06.313+0000 I  CONTROL  [initandlisten] 
2019-11-06T00:20:06.313+0000 I  STORAGE  [initandlisten] createCollection: admin.system.version with provided UUID: 0036f68e-6f27-43f1-9257-9d0101867e98 and options: { uuid: UUID("0036f68e-6f27-43f1-9257-9d0101867e98") }
2019-11-06T00:20:06.341+0000 I  INDEX    [initandlisten] index build: done building index _id_ on ns admin.system.version
2019-11-06T00:20:06.341+0000 I  SHARDING [initandlisten] Marking collection admin.system.version as collection version: <unsharded>
2019-11-06T00:20:06.341+0000 I  COMMAND  [initandlisten] setting featureCompatibilityVersion to 4.2
2019-11-06T00:20:06.347+0000 I  SHARDING [initandlisten] Marking collection local.system.replset as collection version: <unsharded>
```

Note that tests here for this PR will fail until the above go-mod-secrets PR is pulled in, then I will update the go.mod here with that new version of go-mod-secrets.