### PR TITLE
Enable mongo container works in security mode

### DIFF
--- a/cmd/Dockerfile.aarch64
+++ b/cmd/Dockerfile.aarch64
@@ -38,10 +38,7 @@ RUN \
     mkdir /data && mkdir /data/db
 
 #expose Mongodb's port
-EXPOSE 27017
-
-ARG EDGEX_SECURITY_SECRET_STORE_DEFAULT=false
-ENV EDGEX_SECURITY_SECRET_STORE=$EDGEX_SECURITY_SECRET_STORE_DEFAULT
+EXPOSE 27017    
 
 WORKDIR /edgex-mongo
 COPY --from=builder /edgex-mongo/cmd/edgex-mongo /edgex-mongo/cmd/

--- a/cmd/Dockerfile.aarch64
+++ b/cmd/Dockerfile.aarch64
@@ -30,17 +30,13 @@ MAINTAINER Diana Atanasova
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends wget libcurl3 php-curl && rm -rf /var/lib/apt/lists/* && \
-    addgroup mongodb && \
-    adduser --system --ingroup mongodb mongodb && \
     wget http://fastdl.mongodb.org/linux/mongodb-linux-arm64-ubuntu1604-4.0.10.tgz && \
     tar xf mongodb-linux-arm64-ubuntu1604-4.0.10.tgz && \
     mv mongodb-linux-aarch64-ubuntu1604-4.0.10/bin/mongod /usr/local/bin && \
     mv mongodb-linux-aarch64-ubuntu1604-4.0.10/bin/mongo /usr/local/bin && \
     rm -rf mongo mongodb-linux-arm64-ubuntu1604-4.0.10.tgz mongodb-linux-aarch64-ubuntu1604-4.0.10 && \
-    mkdir /data && mkdir /data/db && \
-    chown mongodb:mongodb /data/db
+    mkdir /data && mkdir /data/db
 
-USER mongodb
 #expose Mongodb's port
 EXPOSE 27017
 


### PR DESCRIPTION
Enable mongo container works in security mode, by removing env variable  'EDGEX_SECURITY_SECRET_STORE' from docker compose file
