### PR TITLE
Enable ARM64 Security

### DIFF
--- a/cmd/Dockerfile.aarch64
+++ b/cmd/Dockerfile.aarch64
@@ -40,9 +40,6 @@ RUN \
 #expose Mongodb's port
 EXPOSE 27017
 
-ARG EDGEX_SECURITY_SECRET_STORE_DEFAULT=false
-ENV EDGEX_SECURITY_SECRET_STORE=$EDGEX_SECURITY_SECRET_STORE_DEFAULT
-
 WORKDIR /edgex-mongo
 COPY --from=builder /edgex-mongo/cmd/edgex-mongo /edgex-mongo/cmd/
 COPY --from=builder /edgex-mongo/cmd/res/docker/configuration.toml /edgex-mongo/cmd/res/docker/configuration.toml


### PR DESCRIPTION
Removed environment vars from ARM64 Dockerfile that were disabling
security.

Fix #63

Signed-off-by: Trevor Conn <trevor_conn@dell.com>