### PR TITLE
internal/secure/config.go: provide RetryWaitPeriod as string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 vendor
 .project
 .vscode/
+
+cmd/edgex-mongo

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/docker-edgex-mongo
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.17
-	github.com/edgexfoundry/go-mod-secrets v0.0.9
+	github.com/edgexfoundry/go-mod-secrets v0.0.10
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/internal/secure/config.go
+++ b/internal/secure/config.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"time"
 
 	"github.com/BurntSushi/toml"
 
@@ -44,11 +43,6 @@ func LoadConfig() (*pkg.Configuration, error) {
 		return nil, err
 	}
 
-	retryWaitPeriodTime, err := time.ParseDuration(secureConfig.SecretStore.RetryWaitPeriod)
-	if err != nil {
-		return nil, err
-	}
-
 	token, err := getAccessToken(secureConfig.SecretStore.TokenPath)
 	if err != nil {
 		return nil, err
@@ -63,7 +57,7 @@ func LoadConfig() (*pkg.Configuration, error) {
 		ServerName:              secureConfig.SecretStore.SNI,
 		Authentication:          secrets.AuthenticationInfo{AuthType: pkg.VaultToken, AuthToken: token},
 		AdditionalRetryAttempts: secureConfig.SecretStore.AdditionalRetryAttempts,
-		RetryWaitPeriod:         retryWaitPeriodTime,
+		RetryWaitPeriod:         secureConfig.SecretStore.RetryWaitPeriod,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This is meant in conjunction with https://github.com/edgexfoundry/go-mod-secrets/pull/38, where go-mod-secrets will do the parsing of the time, so that clients of go-mod-secrets just take in simple values and go-mod-secrets figures out what to do with them.

To test this locally, I pushed my go-mod-secrets branch to my fork, so you can replace go-mod-secrets in go.mod like so:

```patch
diff --git a/go.mod b/go.mod
index 09b031a..2d44366 100644
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,6 @@ require (
        gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
 
+replace github.com/edgexfoundry/go-mod-secrets => github.com/anonymouse64/go-mod-secrets master
+
 go 1.12
```

The tests here will fail until the go-mod-secrets PR is merged and the merge job runs which tags the commit. After a new release of go-mod-secrets is available I will force push this PR to use the new version of go-mod-secrets in go.mod.

Also drive-by update go.mod to 1.12 and ignore the compiled binary file.

See https://github.com/edgexfoundry/edgex-go/issues/2092 and https://github.com/edgexfoundry/edgex-go/pull/2087#discussion_r343742590