### PR TITLE
internal/secure/config.go: specify 10 retry attempts @ 1 Hz (master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 vendor
 .project
 .vscode/
+
+cmd/edgex-mongo

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -30,6 +30,8 @@
   CACertPath = "/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
   TokenPath = "/vault/config/assets/resp-init.json"
   SNI = "localhost"
+  AdditionalRetryAttempts = 10
+  RetryWaitPeriod = "1s"
 
 [Mongo]
   Host = 'localhost'

--- a/cmd/res/docker/configuration.toml
+++ b/cmd/res/docker/configuration.toml
@@ -30,6 +30,8 @@
   CACertPath = "/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
   TokenPath = "/vault/config/assets/resp-init.json"
   SNI = "edgex-vault"
+  AdditionalRetryAttempts = 10
+  RetryWaitPeriod = "1s"
 
 [Mongo]
   Host = 'localhost'

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/docker-edgex-mongo
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.17
-	github.com/edgexfoundry/go-mod-secrets v0.0.9
+	github.com/edgexfoundry/go-mod-secrets v0.0.10
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/docker-edgex-mongo
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.17
-	github.com/edgexfoundry/go-mod-secrets v0.0.7
+	github.com/edgexfoundry/go-mod-secrets v0.0.9
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -59,7 +59,9 @@ type SecretStoreInfo struct {
 	CACertPath string
 	Path       string
 	// SNI - Server Name Identifier
-	SNI string
+	SNI                     string
+	AdditionalRetryAttempts int
+	RetryWaitPeriod         string
 }
 
 func (s SecretStoreInfo) GetSecretStoreBaseURL() string {

--- a/internal/secure/config.go
+++ b/internal/secure/config.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	"github.com/BurntSushi/toml"
 
@@ -49,13 +50,15 @@ func LoadConfig() (*pkg.Configuration, error) {
 	}
 
 	secretClient, err := secrets.NewSecretClient(secrets.SecretConfig{
-		Port:           secureConfig.SecretStore.Port,
-		Host:           secureConfig.SecretStore.Server,
-		Path:           secureConfig.SecretStore.Path,
-		Protocol:       "https",
-		RootCaCertPath: secureConfig.SecretStore.CACertPath,
-		ServerName:     secureConfig.SecretStore.SNI,
-		Authentication: secrets.AuthenticationInfo{AuthType: pkg.VaultToken, AuthToken: token},
+		Port:                    secureConfig.SecretStore.Port,
+		Host:                    secureConfig.SecretStore.Server,
+		Path:                    secureConfig.SecretStore.Path,
+		Protocol:                "https",
+		RootCaCertPath:          secureConfig.SecretStore.CACertPath,
+		ServerName:              secureConfig.SecretStore.SNI,
+		Authentication:          secrets.AuthenticationInfo{AuthType: pkg.VaultToken, AuthToken: token},
+		AdditionalRetryAttempts: 10,
+		RetryWaitPeriod:         time.Second,
 	})
 
 	if err != nil {
@@ -66,7 +69,7 @@ func LoadConfig() (*pkg.Configuration, error) {
 	var credentials = make(map[string]pkg.DatabaseInfo)
 	for _, dbName := range getDatabaseNames(secureConfig) {
 		pkg.LoggingClient.Debug(fmt.Sprintf("reading secrets from '%s/%s' path", secureConfig.SecretStore.Path, dbName))
-		secrets, err := secretClient.GetSecrets("/"+dbName,"username", "password")
+		secrets, err := secretClient.GetSecrets("/"+dbName, "username", "password")
 		if err != nil {
 			pkg.LoggingClient.Error(fmt.Sprintf("failed to read secret stores data for '%s/%s' path: %s", secureConfig.SecretStore.Path, dbName, err.Error()))
 			return nil, err

--- a/internal/secure/config.go
+++ b/internal/secure/config.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"time"
 
 	"github.com/BurntSushi/toml"
 
@@ -44,11 +43,6 @@ func LoadConfig() (*pkg.Configuration, error) {
 		return nil, err
 	}
 
-	retryWaitPeriodTime, err := time.ParseDuration(secureConfig.SecretStore.RetryWaitPeriod)
-	if err != nil {
-		return nil, err
-	}
-
 	token, err := getAccessToken(secureConfig.SecretStore.TokenPath)
 	if err != nil {
 		return nil, err
@@ -63,7 +57,7 @@ func LoadConfig() (*pkg.Configuration, error) {
 		ServerName:              secureConfig.SecretStore.SNI,
 		Authentication:          secrets.AuthenticationInfo{AuthType: pkg.VaultToken, AuthToken: token},
 		AdditionalRetryAttempts: secureConfig.SecretStore.AdditionalRetryAttempts,
-		RetryWaitPeriod:         retryWaitPeriodTime,
+		RetryWaitPeriod:         secureConfig.SecretStore.RetryWaitPeriod,
 	})
 
 	if err != nil {

--- a/internal/secure/config.go
+++ b/internal/secure/config.go
@@ -44,6 +44,11 @@ func LoadConfig() (*pkg.Configuration, error) {
 		return nil, err
 	}
 
+	retryWaitPeriodTime, err := time.ParseDuration(secureConfig.SecretStore.RetryWaitPeriod)
+	if err != nil {
+		return nil, err
+	}
+
 	token, err := getAccessToken(secureConfig.SecretStore.TokenPath)
 	if err != nil {
 		return nil, err
@@ -57,8 +62,8 @@ func LoadConfig() (*pkg.Configuration, error) {
 		RootCaCertPath:          secureConfig.SecretStore.CACertPath,
 		ServerName:              secureConfig.SecretStore.SNI,
 		Authentication:          secrets.AuthenticationInfo{AuthType: pkg.VaultToken, AuthToken: token},
-		AdditionalRetryAttempts: 10,
-		RetryWaitPeriod:         time.Second,
+		AdditionalRetryAttempts: secureConfig.SecretStore.AdditionalRetryAttempts,
+		RetryWaitPeriod:         retryWaitPeriodTime,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This is a duplicate of https://github.com/edgexfoundry/docker-edgex-mongo/pull/59 and https://github.com/edgexfoundry/docker-edgex-mongo/pull/67 combined into one PR for master/Geneva.