### PR TITLE
Update CA TLS path for docker environment

### DIFF
--- a/cmd/res/docker/configuration.toml
+++ b/cmd/res/docker/configuration.toml
@@ -27,7 +27,7 @@
   Server = "edgex-vault"
   Port = 8200
   Path = "/v1/secret/edgex/mongo"
-  CACertPath = "/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"
+  CACertPath = "/tmp/edgex/secrets/ca/ca.pem"
   TokenPath = "/vault/config/assets/resp-init.json"
   SNI = "edgex-vault"
   AdditionalRetryAttempts = 10


### PR DESCRIPTION
The CA TLS path is changed due to the change of issue #1716 on TLS path changes.

Related to fixing [edgex-go issue #1716](https://github.com/edgexfoundry/edgex-go/issues/1716), on step 2 of PR [edgexfoundry#2146](https://github.com/edgexfoundry/edgex-go/pull/2146)

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>