### PR TITLE
Update relevant files in docker-edgex-mongo for Go 1.13. Resol…

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -16,7 +16,7 @@
 ###############################################################################
 # Mongo DB image for EdgeX Foundry
 
-FROM golang:1.12-alpine3.9 AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /edgex-mongo

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
 
-go 1.12
+go 1.13


### PR DESCRIPTION
Fix #79  
- The file `Jenkinsfile ` was was not modified after confirming with `DevOps`:
```
- Ernesto Ojeda  3:15 PM
edgeXBuildDocker depends only on the Dockerfile in the repo. It only cares about doing a docker build . So for docker-edgex-mongo, the only thing you would have to update is this file: https://github.com/edgexfoundry/docker-edgex-mongo/blob/master/cmd/Dockerfile#L19 (edited) 
```