### PR TITLE
Start mongo with enabled access control

### DIFF
--- a/bin/edgex-mongo-launch.sh
+++ b/bin/edgex-mongo-launch.sh
@@ -9,14 +9,21 @@
 set -e
 
 ###
-# Run MongoDB
+# Run MongoDB bind to localhost.
 ###
-mongod --bind_ip_all &
+mongod &
 
 ###
-# Run Edgex-Mongo Go Application and keep the process/container alive
+# Run Edgex-Mongo Go Application and initiate the database
 ###
 cd cmd/
 ./edgex-mongo --profile=docker --confdir=res
+
+
+###
+# Restart Edgex-Mongo with enabled authentication and bind_ip_all
+###
+mongod --shutdown
+mongod --auth --bind_ip_all &
 wait
 


### PR DESCRIPTION
Mongo DB is started firstly bound to localhost, then all users, databases and collection are initialized,
and finally mongo db is restarted with enabled access control and --bind_ip_all

Fix: https://github.com/edgexfoundry/docker-edgex-mongo/issues/77

Note: When database credentials are not generated on every restart of the system, a follow up issue could be opened, that so that the logic inside edgex-mongo and the restart of mongo itself to happen only on the first start . 

Signed-off-by: difince <dianaa@vmware.com>