### PR TITLE
Upgrade for Mongo base image to mongo:4.2.3-bionic

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -32,7 +32,7 @@ COPY . .
 
 RUN make cmd/edgex-mongo
 
-FROM mongo:4.2.0-bionic
+FROM mongo:4.2.3-bionic
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: VMWare'


### PR DESCRIPTION
Snyk reporting lots of CVE's with older versions of base images
so upgrading to latest available to fix some of them.