### PR TITLE
Do not provision db credential on each restart

### DIFF
--- a/bin/edgex-mongo-launch.sh
+++ b/bin/edgex-mongo-launch.sh
@@ -8,22 +8,28 @@
 #Exit the script immediately if a command exits with a non-zero status
 set -e
 
-###
-# Run MongoDB bind to localhost.
-###
-mongod &
+#sentinel file used to determine if the database was already initialized
+: ${DB_INITIALIZATION_FLAG:=/data/db/.edgex-mongo-database-setup-done}
 
-###
-# Run Edgex-Mongo Go Application and initiate the database
-###
-cd cmd/
-./edgex-mongo --profile=docker --confdir=res
+if [ ! -f "${DB_INITIALIZATION_FLAG}" ]; then
+    # Run Mongo DB bind to localhost.
+    mongod &
 
+    echo "Run database initialization process"
+    cd cmd/
+    ./edgex-mongo --profile=docker --confdir=res
 
-###
-# Restart Edgex-Mongo with enabled authentication and bind_ip_all
-###
-mongod --shutdown
+    #Shutdown mongo and later to be started up with enabled authentication
+    mongod --shutdown
+
+    echo "Signaling mongo database initialization process is completed"
+    mkdir -p `dirname "${DB_INITIALIZATION_FLAG}"`
+    touch "${DB_INITIALIZATION_FLAG}"
+else
+   echo "Database already has been initialized"
+fi
+
+# Start Mongo DB with enabled authentication and bind_ip_all
 mongod --auth --bind_ip_all &
 wait
 


### PR DESCRIPTION
If `/tmp/edgex/secrets/edgex-mongo/.mongo-database-setup-done` does not exist
run mongo database bind to localhost and re-provision all db collections and credentials
else - immediately run mongo database with enabled authentication

Fix: https://github.com/edgexfoundry/docker-edgex-mongo/issues/85

Signed-off-by: difince <dianaa@vmware.com>